### PR TITLE
ci: check mold integration

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,6 @@
 [target.x86_64-unknown-linux-gnu]
-rustflags = ["-C", "link-arg=-fuse-ld=mold"]
+linker = "clang"
+rustflags = ["-C", "link-arg=-fuse-ld=$DEVENV_PROFILE/bin/mold"]
 
 [target.wasm32-unknown-unknown]
 runner = 'wasm-bindgen-test-runner'

--- a/devenv.lock
+++ b/devenv.lock
@@ -53,10 +53,10 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1730692470,
+        "lastModified": 1730710416,
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8a759c910ebf0bc0aab26ae0807ad34b42211b23",
+        "rev": "efd6331c95521d24bc7802fc380af9509cf44a15",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
### Description

OpenSSL breaks tests in CI (not locally) when integrating `mold`. Check to see what works. 