### PR TITLE
chore(devenv): auto install rustfmt nightly

### DIFF
--- a/devenv.lock
+++ b/devenv.lock
@@ -3,10 +3,10 @@
     "devenv": {
       "locked": {
         "dir": "src/modules",
-        "lastModified": 1741670053,
+        "lastModified": 1741953770,
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "47abb5dfd5b7824a0979ef86f3986aea48847312",
+        "rev": "984272189d4c23e3663a4d7e83b3cf3a532aa53d",
         "type": "github"
       },
       "original": {
@@ -118,10 +118,10 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1741919466,
+        "lastModified": 1742005800,
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "8b137260b776525542d47d3a4dbac753df478a42",
+        "rev": "028cd247a6375f83b94adc33d83676480fc9c294",
         "type": "github"
       },
       "original": {

--- a/devenv.nix
+++ b/devenv.nix
@@ -31,6 +31,12 @@
 
   # disable dotenv since it breaks the variable interpolation supported by `direnv`
   dotenv.disableHint = true;
+	tasks = {
+    "rustfmt:nightly" = {
+      exec = "rustup toolchain install nightly --component rustfmt --force";
+      before = [ "devenv:enterShell" ];
+    };
+  };
 
   scripts.anchor = {
     exec = ''


### PR DESCRIPTION
Added a new task for installing the nightly version of rustfmt in devenv.nix whenever the shell is entered